### PR TITLE
Refactor: change live/ready probe path

### DIFF
--- a/charts/lambda-rpc/Chart.yaml
+++ b/charts/lambda-rpc/Chart.yaml
@@ -30,4 +30,4 @@ version: 1.0.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.0.1"

--- a/charts/lambda-rpc/Chart.yaml
+++ b/charts/lambda-rpc/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lambda-rpc/values.yaml
+++ b/charts/lambda-rpc/values.yaml
@@ -70,7 +70,7 @@ resources: {}
 
 livenessProbe:
   httpGet:
-    path: /live
+    path: /api/live
     port: http
     initialDelaySeconds: 30
     periodSeconds: 30
@@ -80,7 +80,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /ready
+    path: /api/ready
     port: http
     initialDelaySeconds: 30
     periodSeconds: 30


### PR DESCRIPTION
Changes the readiness/liveness probe path according to the latest rpc release.
It causes breaking changes to the rpc <1.0.1